### PR TITLE
fixed filtering of movies by genre

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -271,5 +271,5 @@ h4{
 }
 
 [hidden]{
-  display: none;
+  display: none !important;
 }


### PR DESCRIPTION
The hidden attribute applied during the filtering of movies was being overridden. Placed !important on hidden attribute CSS selector as outlined in [https://css-tricks.com/the-hidden-attribute-is-visibly-weak/](url).