### PR TITLE
added helper function to update display of movies left count

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -47,6 +47,7 @@ async function toggleCompleted(e) {
         const data = await response.json()
         console.log(data)
         toggleCompletedStyle(this.parentNode)
+        updateMoviesLeftDisplay()
     }catch(err){
         console.log(err)
     }
@@ -61,6 +62,19 @@ function toggleCompletedStyle(listItem) {
                 : (classes.remove('completed'), classes.add('not'))
         }
     })
+}
+
+function updateMoviesLeftDisplay() {
+    const h2 = document.querySelector('h2')
+    const moviesLeft = document.querySelectorAll('.not').length / 2
+    h2.innerText = h2.innerText
+        .split(' ')
+        .slice(0, 2)
+        .concat(
+            moviesLeft,
+            h2.innerText.split(' ').slice(3)
+        )
+        .join(' ')
 }
 
 function maintainListPreference() {


### PR DESCRIPTION
Since removing page reload on updating movies completed/not, movie count list did not reflect accurately until page re-render.
Added helper function updateMoviesLeftDisplay() to handle the accurate count until a new page render is triggered.